### PR TITLE
feat: add total votes tracking to Poll account

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -30,6 +30,11 @@ pub mod voting {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+
+        let poll = &mut ctx.accounts.poll;
+        poll.candidate_amount += 1;
+        msg!("Candidate {} added to poll {}", candidate.candidate_name, poll.poll_id);
+        msg!("Poll {} has {} candidates", poll.poll_id, poll.candidate_amount);
         Ok(())
     }
 

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -12,7 +12,8 @@ pub mod voting {
                             poll_id: u64,
                             description: String,
                             poll_start: u64,
-                            poll_end: u64) -> Result<()> {
+                            poll_end: u64
+                            ) -> Result<()> {
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
@@ -20,6 +21,7 @@ pub mod voting {
         poll.poll_start = poll_start;
         poll.poll_end = poll_end;
         poll.candidate_amount = 0;
+        poll.total_votes = 0;
         Ok(())
     }
 
@@ -41,9 +43,12 @@ pub mod voting {
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_votes += 1;
+        let poll = &mut ctx.accounts.poll;
+        poll.total_votes += 1;
 
         msg!("Voted for candidate: {}", candidate.candidate_name);
         msg!("Votes: {}", candidate.candidate_votes);
+        msg!("Total votes in poll: {}", poll.total_votes);
         Ok(())
     }
 
@@ -129,4 +134,5 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+    pub total_votes: u64,
 }


### PR DESCRIPTION
Problem:
Previously, there was no way to view the total number of votes cast in a poll. This made it difficult to understand the overall participation and evaluate poll engagement.

Solution:

Introduced a new total_votes field in the Poll account.

This field is incremented each time the vote instruction is called.

Now, alongside individual candidate votes, the total number of votes cast in a poll can be easily tracked.

This update improves poll result transparency and allows better tracking of voter turnout.

Closes: #2
Registered Email: mndinesh674@gmail.com