### PR TITLE
Ensure voting happens only during active poll period

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -12,7 +12,8 @@ pub mod voting {
                             poll_id: u64,
                             description: String,
                             poll_start: u64,
-                            poll_end: u64) -> Result<()> {
+                            poll_end: u64
+                            ) -> Result<()> {
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
@@ -20,6 +21,7 @@ pub mod voting {
         poll.poll_start = poll_start;
         poll.poll_end = poll_end;
         poll.candidate_amount = 0;
+        poll.total_votes = 0;
         Ok(())
     }
 
@@ -30,15 +32,36 @@ pub mod voting {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+
+        let poll = &mut ctx.accounts.poll;
+        poll.candidate_amount += 1;
+        msg!("Candidate {} added to poll {}", candidate.candidate_name, poll.poll_id);
+        msg!("Poll {} has {} candidates", poll.poll_id, poll.candidate_amount);
         Ok(())
     }
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        let poll = &mut ctx.accounts.poll;
+
+        if current_time < poll.poll_start {
+            return Err(VotingError::PollNotStarted.into());
+        }
+
+        if current_time > poll.poll_end {
+            return Err(VotingError::PollEnded.into());
+        }
+
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_votes += 1;
+        
+        poll.total_votes += 1;
 
         msg!("Voted for candidate: {}", candidate.candidate_name);
         msg!("Votes: {}", candidate.candidate_votes);
+        msg!("Total votes in poll: {}", poll.total_votes);
         Ok(())
     }
 
@@ -124,4 +147,13 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+    pub total_votes: u64,
+}
+
+#[error_code]
+pub enum VotingError {
+    #[msg("Poll has not started yet")]
+    PollNotStarted,
+    #[msg("Poll has ended")]
+    PollEnded,
 }


### PR DESCRIPTION
Problem:
The vote instruction previously allowed casting votes at any time, even before the poll started or after it ended. This led to invalid votes and compromised the integrity of the poll.

Solution:

Added time validation using the Solana Clock sysvar to the vote instruction.

Now, voting is only allowed when current_time is between poll.poll_start and poll.poll_end.

Introduced a custom VotingError enum with meaningful messages:

PollNotStarted: Returned when the poll hasn’t begun.

PollEnded: Returned when the poll has already ended.

These checks ensure accurate and fair voting strictly within the poll’s intended timeframe.


closes: #3

Registered mail : mndinesh674@gmail.com
. 
 This pull request was created for https://app.gib.work/bounties/443dd8db-ecc1-4797-a4a8-3bc1c139ef16 in an attempt to solve a bounty #3 . Payment for the bounty is immediately sent to the contributor after merge.