### PR TITLE
Add validation to prevent past-dated poll_end timestamps during poll creation

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -12,7 +12,20 @@ pub mod voting {
                             poll_id: u64,
                             description: String,
                             poll_start: u64,
-                            poll_end: u64) -> Result<()> {
+                            poll_end: u64
+                            ) -> Result<()> {
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        if poll_start <= current_time {
+            return Err(VotingError::PollStartInPast.into());
+        }
+        if poll_end <= poll_start {
+            return Err(VotingError::PollEndBeforeStart.into());
+        }
+        if poll_end <= current_time {
+            return Err(VotingError::PollEndInPast.into());
+        }
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
@@ -20,6 +33,7 @@ pub mod voting {
         poll.poll_start = poll_start;
         poll.poll_end = poll_end;
         poll.candidate_amount = 0;
+        poll.total_votes = 0;
         Ok(())
     }
 
@@ -30,15 +44,36 @@ pub mod voting {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+
+        let poll = &mut ctx.accounts.poll;
+        poll.candidate_amount += 1;
+        msg!("Candidate {} added to poll {}", candidate.candidate_name, poll.poll_id);
+        msg!("Poll {} has {} candidates", poll.poll_id, poll.candidate_amount);
         Ok(())
     }
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        let poll = &mut ctx.accounts.poll;
+
+        if current_time < poll.poll_start {
+            return Err(VotingError::PollNotStarted.into());
+        }
+
+        if current_time > poll.poll_end {
+            return Err(VotingError::PollEnded.into());
+        }
+
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_votes += 1;
+      
+        poll.total_votes += 1;
 
         msg!("Voted for candidate: {}", candidate.candidate_name);
         msg!("Votes: {}", candidate.candidate_votes);
+        msg!("Total votes in poll: {}", poll.total_votes);
         Ok(())
     }
 
@@ -124,4 +159,19 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+    pub total_votes: u64,
+}
+
+#[error_code]
+pub enum VotingError {
+    #[msg("Poll has not started yet")]
+    PollNotStarted,
+    #[msg("Poll has ended")]
+    PollEnded,
+    #[msg("Poll end time is before or equal to start time")]
+    PollEndBeforeStart,
+    #[msg("Poll start time is in the past")]
+    PollStartInPast,
+    #[msg("Poll end time is in the past")]
+    PollEndInPast,
 }


### PR DESCRIPTION
Previously, there was no check to ensure that `poll_end` was set to a future timestamp. This allowed for the creation of polls that were already expired at the time of initialization, leading to invalid or unusable polls on-chain.

## Solution
- Added validation in `initialize_poll`:
  - Rejects if `poll_start` is less than or equal to the current Unix timestamp.
  - Rejects if `poll_end` is less than or equal to `poll_start`.
  - Rejects if `poll_end` is less than or equal to the current Unix timestamp.

closes: #4

Registered mail : mndinesh674@gmail.com. 
 This pull request was created for https://app.gib.work/bounties/f083c1c0-bc14-43ed-88c6-d3846f77be98 in an attempt to solve a bounty #4 . Payment for the bounty is immediately sent to the contributor after merge.