### PR TITLE
Fix: Added validation for poll_start & poll_end Timestamp During Poll Initialization

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -8,13 +8,32 @@ declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 pub mod voting {
     use super::*;
 
-    pub fn initialize_poll(ctx: Context<InitializePoll>, 
-                            poll_id: u64,
-                            description: String,
-                            poll_start: u64,
-                            poll_end: u64) -> Result<()> {
-
+    pub fn initialize_poll(
+        ctx: Context<InitializePoll>,
+        poll_id: u64,
+        description: String,
+        poll_start: u64,
+        poll_end: u64
+    ) -> Result<()> {
         let poll = &mut ctx.accounts.poll;
+        let clock = Clock::get()?;
+        let now = clock.unix_timestamp as u64;
+
+        let min_unix_timestamp = 1_000_000_000;
+        let max_unix_timestamp = 4_000_000_000;
+
+        if poll_start < min_unix_timestamp || poll_start > max_unix_timestamp {
+            return Err(Errors::InvalidTimestamp.into());
+        }
+
+        if poll_end <= now {
+            return Err(Errors::PollEndInThePast.into());
+        }
+
+        if poll_start >= poll_end {
+            return Err(Errors::InvalidEndDate.into());
+        }
+
         poll.poll_id = poll_id;
         poll.description = description;
         poll.poll_start = poll_start;
@@ -23,26 +42,25 @@ pub mod voting {
         Ok(())
     }
 
-    pub fn initialize_candidate(ctx: Context<InitializeCandidate>, 
-                                candidate_name: String,
-                                _poll_id: u64
-                            ) -> Result<()> {
+    pub fn initialize_candidate(
+        ctx: Context<InitializeCandidate>,
+        candidate_name: String,
+        _poll_id: u64
+    ) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
         Ok(())
     }
-
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_votes += 1;
-
         msg!("Voted for candidate: {}", candidate.candidate_name);
         msg!("Votes: {}", candidate.candidate_votes);
         Ok(())
     }
-
 }
+
 
 #[derive(Accounts)]
 #[instruction(candidate_name: String, poll_id: u64)]
@@ -50,10 +68,7 @@ pub struct Vote<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(
-        seeds = [poll_id.to_le_bytes().as_ref()],
-        bump
-      )]
+    #[account(seeds = [poll_id.to_le_bytes().as_ref()], bump)]
     pub poll: Account<'info, Poll>,
 
     #[account(
@@ -62,17 +77,14 @@ pub struct Vote<'info> {
       bump
     )]
     pub candidate: Account<'info, Candidate>,
-
     pub system_program: Program<'info, System>,
 }
-
 
 #[derive(Accounts)]
 #[instruction(candidate_name: String, poll_id: u64)]
 pub struct InitializeCandidate<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
-
     #[account(
         mut,
         seeds = [poll_id.to_le_bytes().as_ref()],
@@ -81,11 +93,11 @@ pub struct InitializeCandidate<'info> {
     pub poll: Account<'info, Poll>,
 
     #[account(
-      init,
-      payer = signer,
-      space = 8 + Candidate::INIT_SPACE,
-      seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
-      bump
+        init,
+        payer = signer,
+        space = 8 + Candidate::INIT_SPACE,
+        seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
+        bump
     )]
     pub candidate: Account<'info, Candidate>,
     pub system_program: Program<'info, System>,
@@ -105,11 +117,11 @@ pub struct InitializePoll<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
     #[account(
-      init,
-      payer = signer,
-      space = 8 + Poll::INIT_SPACE,
-      seeds = [poll_id.to_le_bytes().as_ref()],
-      bump
+        init,
+        payer = signer,
+        space = 8 + Poll::INIT_SPACE,
+        seeds = [poll_id.to_le_bytes().as_ref()],
+        bump
     )]
     pub poll: Account<'info, Poll>,
     pub system_program: Program<'info, System>,
@@ -124,4 +136,16 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[error_code]
+pub enum Errors {
+    #[msg("Poll end date is in the past")]
+    PollEndInThePast,
+
+    #[msg("Provided timestamp is not a valid Unix timestamp.")]
+    InvalidTimestamp,
+
+    #[msg("Poll end date is before poll start date")]
+    InvalidEndDate,
 }

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -213,6 +213,23 @@
       ]
     }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "PollEndInThePast",
+      "msg": "Poll end date is in the past"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidTimestamp",
+      "msg": "Provided timestamp is not a valid Unix timestamp."
+    },
+    {
+      "code": 6002,
+      "name": "InvalidEndDate",
+      "msg": "Poll end date is before poll start date"
+    }
+  ],
   "types": [
     {
       "name": "Candidate",

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -219,6 +219,23 @@ export type Voting = {
       ]
     }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "pollEndInThePast",
+      "msg": "Poll end date is in the past"
+    },
+    {
+      "code": 6001,
+      "name": "invalidTimestamp",
+      "msg": "Provided timestamp is not a valid Unix timestamp."
+    },
+    {
+      "code": 6002,
+      "name": "invalidEndDate",
+      "msg": "Poll end date is before poll start date"
+    }
+  ],
   "types": [
     {
       "name": "candidate",

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -21,11 +21,14 @@ describe("Voting", () => {
   });
 
   it("initializes a poll", async () => {
+    let poll_start = Math.floor(Date.now() / 1000) + 60;
+    let poll_end = poll_start + 60 * 60 * 24;
+
     await votingProgram.methods.initializePoll(
       new anchor.BN(1),
       "What is your favorite color?",
-      new anchor.BN(100),
-      new anchor.BN(1739370789),
+      new anchor.BN(poll_start),
+      new anchor.BN(poll_end),
     ).rpc();
 
     const [pollAddress] = PublicKey.findProgramAddressSync(
@@ -39,7 +42,26 @@ describe("Voting", () => {
 
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
-    expect(poll.pollStart.toNumber()).toBe(100);
+    expect(poll.pollStart.toNumber()).toBe(poll_start);
+  });
+
+  it("fails to initialize poll with invalid timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(2),                              
+        "Invalid timestamp test",                      
+        new anchor.BN(100),                            
+        new anchor.BN(1739370789),                     
+      ).rpc();
+      // if the transaction does not throw, the test fails
+      fail("Expected initializePoll to throw due to invalid timestamp");
+    } catch (err: any) {
+      const logs = err.logs || [];
+      const foundError = logs.some((log: string) =>
+        log.includes("Provided timestamp is not a valid Unix timestamp.")
+      );
+      expect(foundError).toBe(true);
+    }
   });
 
   it("initializes candidates", async () => {


### PR DESCRIPTION
-added poll_start and poll_end time validation in the initialize_poll transaction.
-added the custom error enum based of the condition.
-added the unix time validation.
-added the valid time for the initializes a poll test.
. 
 This pull request was created for https://app.gib.work/bounties/f083c1c0-bc14-43ed-88c6-d3846f77be98 in an attempt to solve a bounty #4 . Payment for the bounty is immediately sent to the contributor after merge.