### PR TITLE
Add validation to prevent creation of expired polls 

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -20,6 +20,7 @@ pub mod voting {
         poll.poll_start = poll_start;
         poll.poll_end = poll_end;
         poll.candidate_amount = 0;
+        poll.total_votes = 0;
         Ok(())
     }
 
@@ -27,18 +28,22 @@ pub mod voting {
                                 candidate_name: String,
                                 _poll_id: u64
                             ) -> Result<()> {
-        let candidate = &mut ctx.accounts.candidate;
+        let candidate = &mut ctx.accounts.candidate; 
+        let poll = &mut ctx.accounts.poll;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+        poll.candidate_amount += 1;
         Ok(())
     }
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
+        let poll = &mut ctx.accounts.poll;
         candidate.candidate_votes += 1;
-
+        poll.total_votes += 1;
         msg!("Voted for candidate: {}", candidate.candidate_name);
         msg!("Votes: {}", candidate.candidate_votes);
+        msg!("Total votes in poll: {}", poll.total_votes);
         Ok(())
     }
 
@@ -51,6 +56,7 @@ pub struct Vote<'info> {
     pub signer: Signer<'info>,
 
     #[account(
+        mut,
         seeds = [poll_id.to_le_bytes().as_ref()],
         bump
       )]
@@ -124,4 +130,5 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+    pub total_votes: u64,
 }

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -39,6 +39,12 @@ pub mod voting {
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         let poll = &mut ctx.accounts.poll;
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+        require!(
+          current_time >= poll.poll_start && current_time <= poll.poll_end,
+          VotingError::PollNotActive
+        );
         candidate.candidate_votes += 1;
         poll.total_votes += 1;
         msg!("Voted for candidate: {}", candidate.candidate_name);
@@ -131,4 +137,10 @@ pub struct Poll {
     pub poll_end: u64,
     pub candidate_amount: u64,
     pub total_votes: u64,
+}
+
+#[error_code]
+pub enum VotingError {
+    #[msg("Poll is not active")]
+    PollNotActive,
 }

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -4,7 +4,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 
-#[program]
+#[program] 
 pub mod voting {
     use super::*;
 
@@ -12,7 +12,11 @@ pub mod voting {
                             poll_id: u64,
                             description: String,
                             poll_start: u64,
-                            poll_end: u64) -> Result<()> {
+                            poll_end: u64) -> Result<()> {                      
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        require!(poll_end > current_time, VotingError::PollEndInPast);
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
@@ -143,4 +147,6 @@ pub struct Poll {
 pub enum VotingError {
     #[msg("Poll is not active")]
     PollNotActive,
+    #[msg("The poll end time must be in the future.")]
+    PollEndInPast,
 }

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -143,6 +143,7 @@
         },
         {
           "name": "poll",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -253,6 +254,10 @@
           },
           {
             "name": "candidate_amount",
+            "type": "u64"
+          },
+          {
+            "name": "total_votes",
             "type": "u64"
           }
         ]

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -214,6 +214,13 @@
       ]
     }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "PollNotActive",
+      "msg": "Poll is not active"
+    }
+  ],
   "types": [
     {
       "name": "Candidate",

--- a/anchor/target/idl/voting.json
+++ b/anchor/target/idl/voting.json
@@ -219,6 +219,11 @@
       "code": 6000,
       "name": "PollNotActive",
       "msg": "Poll is not active"
+    },
+    {
+      "code": 6001,
+      "name": "PollEndInPast",
+      "msg": "The poll end time must be in the future."
     }
   ],
   "types": [

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -149,6 +149,7 @@ export type Voting = {
         },
         {
           "name": "poll",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -259,6 +260,10 @@ export type Voting = {
           },
           {
             "name": "candidateAmount",
+            "type": "u64"
+          },
+          {
+            "name": "totalVotes",
             "type": "u64"
           }
         ]

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -225,6 +225,11 @@ export type Voting = {
       "code": 6000,
       "name": "pollNotActive",
       "msg": "Poll is not active"
+    },
+    {
+      "code": 6001,
+      "name": "pollEndInPast",
+      "msg": "The poll end time must be in the future."
     }
   ],
   "types": [

--- a/anchor/target/types/voting.ts
+++ b/anchor/target/types/voting.ts
@@ -220,6 +220,13 @@ export type Voting = {
       ]
     }
   ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "pollNotActive",
+      "msg": "Poll is not active"
+    }
+  ],
   "types": [
     {
       "name": "candidate",

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -16,7 +16,7 @@ describe("Voting", () => {
     provider = new BankrunProvider(context);
     votingProgram = new anchor.Program<Voting>(
       IDL,
-      provider,
+      provider, 
     );
   });
 
@@ -25,9 +25,8 @@ describe("Voting", () => {
       new anchor.BN(1),
       "What is your favorite color?",
       new anchor.BN(100),
-      new anchor.BN(2533201883),
+      new anchor.BN(3077836800),
     ).rpc();
-
     const [pollAddress] = PublicKey.findProgramAddressSync(
       [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
       votingProgram.programId,
@@ -40,6 +39,15 @@ describe("Voting", () => {
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
     expect(poll.pollStart.toNumber()).toBe(100);
+  });
+
+  it("initializing poll with past timestamp", async () => {
+    await votingProgram.methods.initializePoll(
+      new anchor.BN(1),
+      "What is your favorite fruit?",
+      new anchor.BN(100),
+      new anchor.BN(1577836800),
+    ).rpc();
   });
 
   it("initializes candidates", async () => {

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -69,6 +69,13 @@ describe("Voting", () => {
     console.log(blueCandidate);
     expect(blueCandidate.candidateVotes.toNumber()).toBe(0);
     expect(blueCandidate.candidateName).toBe("Blue");
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+    const poll = await votingProgram.account.poll.fetch(pollAddress); 
+    console.log(poll);
+    expect(poll.candidateAmount.toNumber()).toBe(2);
   });
 
   it("vote candidates", async () => {
@@ -102,5 +109,11 @@ describe("Voting", () => {
     console.log(blueCandidate);
     expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
     expect(blueCandidate.candidateName).toBe("Blue");
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId
+    );
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+    expect(poll.totalVotes.toNumber()).toBe(3);    
   });
 });

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -25,7 +25,7 @@ describe("Voting", () => {
       new anchor.BN(1),
       "What is your favorite color?",
       new anchor.BN(100),
-      new anchor.BN(1739370789),
+      new anchor.BN(2533201883),
     ).rpc();
 
     const [pollAddress] = PublicKey.findProgramAddressSync(


### PR DESCRIPTION
PR Description:
This pull request adds validation to the initialize_poll instruction to prevent creation of expired or illogical polls. Specifically, it ensures that the poll_end timestamp is in the future.

Changes Made:
→ Added validation to check that poll_end > current timestamp (Clock::get()?.unix_timestamp as u64).
→ Introduced custom error code: PollEndInPast

Registered Email:
dhanushprakash194@gmail.com
(Registered for the Solana Devs India Tour Workshop – Chennai). 
 This pull request was created for https://app.gib.work/bounties/f083c1c0-bc14-43ed-88c6-d3846f77be98 in an attempt to solve a bounty #4 . Payment for the bounty is immediately sent to the contributor after merge.